### PR TITLE
Fix README newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Each `76JK_*.js` file is an AWS Lambda function. Example:
 
 - `76JK_NewUser.js`: Register new users
 - `76JK_EditEntry.js`: Update plant journal entries
-- `76JK_GenerateStatic.js`: Create static snapshots for public viewing
+- `76JK_GenerateStatic.js`: Create static HTML snapshots for public viewing


### PR DESCRIPTION
## Summary
- ensure README ends with a newline
- clarify 76JK_GenerateStatic.js bullet

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879bdaa3d9083268c9a8d8365a5c132