### PR TITLE
Fix missing cookie handling

### DIFF
--- a/76JK_PlayMP3.js
+++ b/76JK_PlayMP3.js
@@ -26,6 +26,7 @@ exports.handler= function(event, context, callback) {
 }
 
 const getCookieValue= function(cookieString, name) {
+  if(!cookieString) { return null; }
   var pattern= new RegExp("(^|;\\s*)" + name + "=([^;]*)");
   var match= cookieString.match(pattern);
   return match ? match[2] : null;


### PR DESCRIPTION
## Summary
- avoid TypeError when the Cookie header is absent in PlayMP3 handler

## Testing
- `node -c *.js`

------
https://chatgpt.com/codex/tasks/task_e_6879b62fd7408326978ba986af4d19f8